### PR TITLE
Add `startAngle` parameter to `ThreeSixty::initialize`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediaman/three-sixty",
-  "version": "0.0.3",
+  "version": "0.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mediaman/three-sixty",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "360° library",
   "keywords": [],
   "main": "dist/three-sixty.umd.js",

--- a/src/three-sixty.ts
+++ b/src/three-sixty.ts
@@ -80,8 +80,13 @@ export default class ThreeSixty {
      * Initialize the three sixty widget
      *
      * @param {string[]} images - Array of image sprites
+     * @param {number} startAngle - The initial angle to show (number between 0 and 360)
      */
-    public initialize(images: string[]) {
+    public initialize(images: string[], startAngle: number = 0) {
+        if (startAngle < 0 || startAngle > 360) {
+            throw new Error('The specified start angle must be between 0 and 360.');
+        }
+
         this.images = images;
 
         // Wrap the canvas element
@@ -93,8 +98,18 @@ export default class ThreeSixty {
         this.initializeHotspots();
         this.initializeEventListeners();
 
-        this.imageLoader.load(this.images[0])
-            .then((image) => this.drawAngle(image, 0));
+        let targetImageIndex = Math.round(startAngle / (360 / this.configuration.angles)) - 1;
+        let targetSpriteIndex = Math.floor(targetImageIndex / this.configuration.anglesPerImage) - 1;
+
+        if (targetImageIndex < 0) {
+            targetImageIndex = 0;
+        }
+        if (targetSpriteIndex < 0) {
+            targetSpriteIndex = 0;
+        }
+
+        this.imageLoader.load(this.images[targetSpriteIndex])
+            .then((image) => this.drawAngle(image, targetImageIndex % this.configuration.angles));
     }
 
     /**

--- a/src/three-sixty.ts
+++ b/src/three-sixty.ts
@@ -177,6 +177,23 @@ export default class ThreeSixty {
                 this.hotspotElements.push(hotspotElement);
             });
             this.hotspotElements.forEach((hotSpotElement) => this.containerElement.appendChild(hotSpotElement));
+
+            this.showActiveHotspots();
+        }
+    }
+
+    /**
+     * Show the active hotspots
+     */
+    private showActiveHotspots() {
+        if (this.configuration.hotspots) {
+            this.configuration.hotspots.forEach((hotspot: HotspotInterface, i: number) => {
+                if (hotspot.angle <= this.angle && hotspot.endAngle > this.angle) {
+                    this.hotspotElements[i].classList.add(ThreeSixty.HOTSPOT_ACTIVE_CLASS);
+                } else {
+                    this.hotspotElements[i].classList.remove(ThreeSixty.HOTSPOT_ACTIVE_CLASS);
+                }
+            });
         }
     }
 
@@ -236,16 +253,7 @@ export default class ThreeSixty {
         const targetImageIndex = (Math.floor((Math.atan2(sn, -cs) / (Math.PI * 2) + 0.5) * this.configuration.angles) % this.configuration.angles);
         const targetSpriteIndex = Math.floor(targetImageIndex / this.configuration.anglesPerImage);
 
-        // Show the current hotspot(s)
-        if (this.configuration.hotspots) {
-            this.configuration.hotspots.forEach((hotspot: HotspotInterface, i: number) => {
-                if (hotspot.angle < this.angle && hotspot.endAngle > this.angle) {
-                    this.hotspotElements[i].classList.add(ThreeSixty.HOTSPOT_ACTIVE_CLASS);
-                } else {
-                    this.hotspotElements[i].classList.remove(ThreeSixty.HOTSPOT_ACTIVE_CLASS);
-                }
-            });
-        }
+        this.showActiveHotspots();
 
         // Load and render new image angle
         this.imageLoader.load(this.images[targetSpriteIndex])

--- a/test/three-sixty.test.ts
+++ b/test/three-sixty.test.ts
@@ -6,7 +6,9 @@ describe('ThreeSixty', () => {
         'http://example.com/image-0.jpg',
         'http://example.com/image-1.jpg',
         'http://example.com/image-2.jpg',
-        'http://example.com/image-3.jpg'
+        'http://example.com/image-3.jpg',
+        'http://example.com/image-4.jpg',
+        'http://example.com/image-5.jpg'
     ];
     const hotspots = [
         {text: 'Lorem ipsum', angle: 0.5, endAngle: 0.7, top: '30%', left: '50%'},
@@ -30,7 +32,9 @@ describe('ThreeSixty', () => {
     afterEach(() => {
         const threeSixtyWrapperElement = document.querySelector(`.${ThreeSixty.CONTAINER_CLASS}`);
 
-        document.body.removeChild(threeSixtyWrapperElement);
+        if (threeSixtyWrapperElement) {
+            document.body.removeChild(threeSixtyWrapperElement);
+        }
     });
 
     describe('::initialize', () => {
@@ -100,6 +104,38 @@ describe('ThreeSixty', () => {
 
                 done();
             }, 50);
+        });
+
+        it('should load the specified start angle', (done) => {
+            const threeSixty = new ThreeSixty(canvasElement, {angles: 36, anglesPerImage: 9});
+            const imageLoader = threeSixty['imageLoader'] as ImageLoader;
+            const initialImageMock = new Image();
+
+            spyOn(imageLoader, 'load').and.returnValue(new Promise((resolve) => resolve(initialImageMock)));
+
+            threeSixty.initialize(imageUrls, 185);
+
+            expect(imageLoader.load).toHaveBeenCalledWith(imageUrls[1]);
+
+            setTimeout(() => {
+                expect(canvas2dContextMock.drawImage).toHaveBeenCalledWith(
+                    initialImageMock,
+                    0,
+                    -canvasElement.height * 18,
+                    canvasElement.width,
+                    canvasElement.height * 9
+                );
+
+                done();
+            }, 50);
+        });
+
+        it('should throw an error if an invalid start angle was specified', () => {
+            const expectedErrorMessage = 'The specified start angle must be between 0 and 360.';
+            const threeSixty = new ThreeSixty(canvasElement, {angles: 36, anglesPerImage: 9});
+
+            expect(() => threeSixty.initialize(imageUrls, -1)).toThrow(expectedErrorMessage);
+            expect(() => threeSixty.initialize(imageUrls, 361)).toThrow(expectedErrorMessage);
         });
 
         it('should load the correct image on drag', (done) => {

--- a/test/three-sixty.test.ts
+++ b/test/three-sixty.test.ts
@@ -138,6 +138,20 @@ describe('ThreeSixty', () => {
             expect(() => threeSixty.initialize(imageUrls, 361)).toThrow(expectedErrorMessage);
         });
 
+        it('should show a hotspot when its configured angle is the start angle', () => {
+            const threeSixty = new ThreeSixty(canvasElement, {angles: 36, anglesPerImage: 9, hotspots: [
+                {text: 'Lorem ipsum', angle: 0.5, endAngle: 0.7, top: '30%', left: '50%'},
+                {text: 'Dolor sit amet', angle: 0, endAngle: 0.3, top: '42%', left: '55%'}
+            ]});
+
+            threeSixty.initialize(imageUrls);
+
+            const threeSixtyWrapperElement = document.querySelector(`.${ThreeSixty.CONTAINER_CLASS}`);
+            const hotspotElements = threeSixtyWrapperElement.querySelectorAll(`.${ThreeSixty.HOTSPOT_CLASS}`);
+
+            expect(hotspotElements[1].classList).toContain(ThreeSixty.HOTSPOT_ACTIVE_CLASS);
+        });
+
         it('should load the correct image on drag', (done) => {
             const threeSixty = new ThreeSixty(canvasElement, {angles: 36, anglesPerImage: 9});
             const imageLoader = threeSixty['imageLoader'] as ImageLoader;


### PR DESCRIPTION
A start angle between 0 and 360 can be passed along with the initialize method to show an initial angle image (Default to 3)